### PR TITLE
Allow setting of SonarQube module key bindings by applying a pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ signPlugin {
 }
 
 publishPlugin {
-    token = System.getenv("PUBLISH_TOKEN") 
+    token = System.getenv("PUBLISH_TOKEN")
     setHidden(findProperty("hidden").toBoolean())
     channels = findProperty("preRelease").toBoolean() ? ["autoconfig-beta"] : ["default", "autoconfig-beta"]
 }
@@ -72,7 +72,8 @@ intellij {
             "Git4Idea",
             "junit",
             "org.jetbrains.plugins.yaml",
-            "org.jetbrains.idea.maven"
+            "org.jetbrains.idea.maven",
+            "org.sonarlint.idea:10.8.1.79205"
     ]
 }
 buildSearchableOptions.enabled = false // Disable because it takes a long time and the plugin doesn't need it
@@ -285,7 +286,7 @@ jsonSchema2Pojo {
     useOptionalForGetters = false
 
     // properties to exclude from generated toString
-    toStringExcludes = ["someProperty"]
+    toStringExcludes = []
 
     // What Java version to target with generated source code (1.6, 1.8, 9, 11, etc).
     // By default, the version will be taken from the Gradle Java plugin's 'sourceCompatibility',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Autoconfig Plugin Properties
-pluginVersion = 1.0.2
+pluginVersion = 1.1.0
 preRelease = false
 hidden = false
 pluginGroup = de.gebit.plugins.autoconfig

--- a/metadata/changelog.html
+++ b/metadata/changelog.html
@@ -5,9 +5,10 @@
     <title>Changelog</title>
 </head>
 <body>
-<h2>1.0.3</h2>
+<h2>1.1.0</h2>
 <ul>
     <li>support setting of module SDK</li>
+    <li>support setting of module SonarQube project keys</li>
 </ul>
 <h2>1.0.2</h2>
 <ul>

--- a/src/main/java/de/gebit/plugins/autoconfig/UpdateModuleHandler.java
+++ b/src/main/java/de/gebit/plugins/autoconfig/UpdateModuleHandler.java
@@ -36,4 +36,8 @@ public interface UpdateModuleHandler<T> extends UpdateSettings<T> {
 	default UpdateTarget getUpdateTarget() {
 		return UpdateTarget.MODULE;
 	}
+
+	default boolean matchesAnyName(Module module, List<String> patterns) {
+		return patterns.stream().anyMatch(p -> module.getName().matches(p));
+	}
 }

--- a/src/main/java/de/gebit/plugins/autoconfig/handlers/sonarqube/SonarQubeModuleHandler.java
+++ b/src/main/java/de/gebit/plugins/autoconfig/handlers/sonarqube/SonarQubeModuleHandler.java
@@ -1,0 +1,59 @@
+package de.gebit.plugins.autoconfig.handlers.sonarqube;
+
+import com.intellij.openapi.module.Module;
+import de.gebit.plugins.autoconfig.UpdateModuleHandler;
+import de.gebit.plugins.autoconfig.handlers.AbstractHandler;
+import de.gebit.plugins.autoconfig.model.SonarQubeConfiguration;
+import org.jetbrains.annotations.NonNls;
+import org.sonarlint.intellij.config.Settings;
+import org.sonarlint.intellij.config.module.SonarLintModuleSettings;
+import org.sonarlint.intellij.config.project.SonarLintProjectSettings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration handler used to synchronise SonarQube module bindings in projects.
+ */
+public class SonarQubeModuleHandler extends AbstractHandler implements UpdateModuleHandler<SonarQubeConfiguration> {
+	private static final @NonNls String CONFIG_SCHEMA_JSON = "/schema/sonarqubeModule.schema.json";
+
+	public static final @NonNls String CONFIG_FILE_NAME = "autoconfigSonarQubeModule.yaml";
+
+	@Override
+	public String getFileName() {
+		return CONFIG_FILE_NAME;
+	}
+
+	@Override
+	public String getJsonSchema() {
+		return CONFIG_SCHEMA_JSON;
+	}
+
+	@Override
+	public String getUpdaterName() {
+		return "SonarQube module configuration updater";
+	}
+
+	@Override
+	public Class<SonarQubeConfiguration> getConfigurationClass() {
+		return SonarQubeConfiguration.class;
+	}
+
+	@Override
+	public boolean acceptModule(SonarQubeConfiguration configuration, Module module) {
+		return matchesAnyName(module, configuration.getModuleFilter());
+	}
+
+	@Override
+	public List<String> updateConfiguration(SonarQubeConfiguration configuration, Module module) {
+		List<String> updatedConfigs = new ArrayList<>();
+		SonarLintProjectSettings projectSettings = Settings.getSettingsFor(module.getProject());
+		if (projectSettings.isBindingEnabled() && configuration.getProjectKey() != null) {
+			SonarLintModuleSettings moduleSettings = Settings.getSettingsFor(module);
+			applySetting(configuration.getProjectKey(), moduleSettings.getProjectKey(), moduleSettings::setProjectKey,
+					updatedConfigs, "SonarQube module key");
+		}
+		return updatedConfigs;
+	}
+}

--- a/src/main/resources/META-INF/plugin-git.xml
+++ b/src/main/resources/META-INF/plugin-git.xml
@@ -1,4 +1,5 @@
 <idea-plugin>
+    <depends>de.gebit.plugins.autoconfig</depends>
     <extensions defaultExtensionNs="de.gebit.plugins.autoconfig">
         <configurationUpdater implementation="de.gebit.plugins.autoconfig.handlers.git.GitHandler"/>
     </extensions>

--- a/src/main/resources/META-INF/plugin-java.xml
+++ b/src/main/resources/META-INF/plugin-java.xml
@@ -1,4 +1,5 @@
 <idea-plugin>
+    <depends>de.gebit.plugins.autoconfig</depends>
     <extensions defaultExtensionNs="de.gebit.plugins.autoconfig">
         <configurationUpdater implementation="de.gebit.plugins.autoconfig.handlers.java.JavaHandler"/>
     </extensions>

--- a/src/main/resources/META-INF/plugin-sonarqube.xml
+++ b/src/main/resources/META-INF/plugin-sonarqube.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <depends>de.gebit.plugins.autoconfig</depends>
     <extensions defaultExtensionNs="de.gebit.plugins.autoconfig">
-        <configurationUpdater implementation="de.gebit.plugins.autoconfig.handlers.maven.MavenHandler"/>
+        <moduleConfigurationUpdater implementation="de.gebit.plugins.autoconfig.handlers.sonarqube.SonarQubeModuleHandler"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
     <depends optional="true" config-file="plugin-maven.xml">org.jetbrains.idea.maven</depends>
     <depends optional="true" config-file="plugin-java.xml">com.intellij.modules.java</depends>
+    <depends optional="true" config-file="plugin-sonarqube.xml">org.sonarlint.idea</depends>
 
     <extensionPoints>
         <extensionPoint name="configurationUpdater" interface="de.gebit.plugins.autoconfig.UpdateHandler" dynamic="true"/>

--- a/src/main/resources/schema/sonarqubeModule.schema.json
+++ b/src/main/resources/schema/sonarqubeModule.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://www.gebit.de/autoconfig-intellij-plugin/sonarqubeModule.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SonarQube configuration",
+  "type": "object",
+  "required": [
+    "moduleFilter"
+  ],
+  "properties": {
+    "moduleFilter": {
+      "type": "array",
+      "description": "List of modules/module regex patterns. Modules that match any of the names/patterns will be configured by this configuration.",
+      "items": {
+        "type": "string",
+        "description": "Module name/pattern"
+      }
+    },
+    "projectKey": {
+      "type": "string",
+      "description": "The SonarQube project key to use for all matching modules"
+    }
+  }
+}


### PR DESCRIPTION
A new SonarLintHandler has been added, allowing a module name pattern matching to set a SonarQube project key.

Example autoconfigSonarLint.yaml:
```
bindings: 
  - modulePattern: base-module-name-.*
    projectKey: module-sonarqube-project
```

Closes #8 